### PR TITLE
Fix typo in parameter name.

### DIFF
--- a/pandora/__init__.py
+++ b/pandora/__init__.py
@@ -349,7 +349,7 @@ class APIClient(BaseAPIClient):
                 musicToken=music_token,
                 stationToken=station_token)
 
-    def create_station(self, search_token=None, atrist_token=None,
+    def create_station(self, search_token=None, artist_token=None,
             track_token=None):
         kwargs = {}
 


### PR DESCRIPTION
Parameter name in method declaration not the same as in method body.