### PR TITLE
Reset tranport on partner auth

### DIFF
--- a/pandora/client.py
+++ b/pandora/client.py
@@ -59,9 +59,7 @@ class BaseAPIClient(object):
                                  deviceModel=self.device,
                                  version=self.transport.API_VERSION)
 
-        self.transport.sync_time = partner["syncTime"]
-        self.transport.partner_auth_token = partner["partnerAuthToken"]
-        self.transport.partner_id = partner["partnerId"]
+        self.transport.set_partner(partner)
 
         return partner
 
@@ -81,8 +79,7 @@ class BaseAPIClient(object):
                               includeSubscriptionExpiration=True,
                               returnCapped=True)
 
-        self.transport.user_id = user["userId"]
-        self.transport.user_auth_token = user["userAuthToken"]
+        self.transport.set_user(user)
 
         return user
 

--- a/tests/test_pandora/test_clientbuilder.py
+++ b/tests/test_pandora/test_clientbuilder.py
@@ -91,13 +91,17 @@ class TestSettingsDictBuilder(TestCase):
     def test_default_values(self):
         client = self._build_minimal()
 
-        self.assertIsNone(client.transport.proxy)
+        self.assertEqual({}, client.transport._http.proxies)
         self.assertEqual(DEFAULT_API_HOST, client.transport.api_host)
         self.assertEqual(APIClient.MED_AUDIO_QUALITY,
                 client.default_audio_quality)
 
     def test_validate_client(self):
         client = self._build_maximal()
+        expected_proxies = {
+                "http": "proxy.example.com",
+                "https": "proxy.example.com"
+                }
 
         self.assertIsNotNone(client.transport.cryptor.bf_in)
         self.assertIsNotNone(client.transport.cryptor.bf_out)
@@ -106,7 +110,7 @@ class TestSettingsDictBuilder(TestCase):
         self.assertEqual("pass", client.partner_password)
         self.assertEqual("dev", client.device)
 
-        self.assertEqual("proxy.example.com", client.transport.proxy)
+        self.assertEqual(expected_proxies, client.transport._http.proxies)
         self.assertEqual("example.com", client.transport.api_host)
         self.assertEqual("high", client.default_audio_quality)
 


### PR DESCRIPTION
This resets the internal state of the transport when partner authentication is being handled. I think this should prevent the auth token errors we're seeing. Testing this on my system now to see if it works.