### PR TITLE
Resolving ad playback issues

### DIFF
--- a/pandora/client.py
+++ b/pandora/client.py
@@ -262,8 +262,8 @@ class APIClient(BaseAPIClient):
         from .models.pandora import AdItem
 
         if not station_id:
-            raise ValueError("The 'station_id' param must be defined, "
-                             "got: '{}'".format(station_id))
+            raise errors.ParameterMissing("The 'station_id' param must be "
+                                          "defined, got: '{}'".format(station_id))
 
         ad_metadata = self.get_ad_metadata(ad_token)
         ad_metadata["stationId"] = station_id

--- a/pandora/client.py
+++ b/pandora/client.py
@@ -263,7 +263,8 @@ class APIClient(BaseAPIClient):
 
         if not station_id:
             raise errors.ParameterMissing("The 'station_id' param must be "
-                                          "defined, got: '{}'".format(station_id))
+                                          "defined, got: '{}'"
+                                          .format(station_id))
 
         ad_metadata = self.get_ad_metadata(ad_token)
         ad_metadata["stationId"] = station_id

--- a/pandora/client.py
+++ b/pandora/client.py
@@ -222,6 +222,7 @@ class APIClient(BaseAPIClient):
 
         genre_stations = GenreStationList.from_json(self, genres)
         genre_stations.checksum = self.get_genre_stations_checksum()
+        return genre_stations
 
     def get_genre_stations_checksum(self):
         return self("station.getGenreStationsChecksum")["checksum"]

--- a/pandora/client.py
+++ b/pandora/client.py
@@ -266,10 +266,10 @@ class APIClient(BaseAPIClient):
                                           "defined, got: '{}'"
                                           .format(station_id))
 
-        ad_metadata = self.get_ad_metadata(ad_token)
-        ad_metadata["stationId"] = station_id
-
-        return AdItem.from_json(self, ad_metadata)
+        ad_item = AdItem.from_json(self, self.get_ad_metadata(ad_token))
+        ad_item.station_id = station_id
+        ad_item.ad_token = ad_token
+        return ad_item
 
     def get_ad_metadata(self, ad_token):
         return self("ad.getAdMetadata",

--- a/pandora/client.py
+++ b/pandora/client.py
@@ -219,9 +219,9 @@ class APIClient(BaseAPIClient):
         from .models.pandora import GenreStationList
 
         genres = self("station.getGenreStations")
-        genres["checksum"] = self.get_genre_stations_checksum()
 
-        return GenreStationList.from_json(self, genres)
+        genre_stations = GenreStationList.from_json(self, genres)
+        genre_stations.checksum = self.get_genre_stations_checksum()
 
     def get_genre_stations_checksum(self):
         return self("station.getGenreStationsChecksum")["checksum"]

--- a/pandora/models/pandora.py
+++ b/pandora/models/pandora.py
@@ -232,8 +232,8 @@ class AdItem(PlaylistModel):
         if self.tracking_tokens:
             self._api_client.register_ad(station_id, self.tracking_tokens)
         else:
-            raise ParameterMissing('No ad tracking tokens available '
-                                          'for registration.')
+            raise ParameterMissing('No ad tracking tokens available for '
+                                   'registration.')
 
     def prepare_playback(self):
         try:

--- a/pandora/models/pandora.py
+++ b/pandora/models/pandora.py
@@ -232,7 +232,7 @@ class AdItem(PlaylistModel):
         if self.tracking_tokens:
             self._api_client.register_ad(station_id, self.tracking_tokens)
         else:
-            raise ParameterMissing('No ad tracking tokens available for '
+            raise ParameterMissing('No ad tracking tokens provided for '
                                    'registration.')
 
     def prepare_playback(self):

--- a/pandora/models/pandora.py
+++ b/pandora/models/pandora.py
@@ -220,8 +220,8 @@ class AdItem(PlaylistModel):
     audio_url = Field("audioUrl")
     image_url = Field("imageUrl")
     click_through_url = Field("clickThroughUrl")
-    station_id = Field("stationId")
-    ad_token = Field("adToken")
+    station_id = None
+    ad_token = None
 
     @property
     def is_ad(self):

--- a/pandora/models/pandora.py
+++ b/pandora/models/pandora.py
@@ -1,6 +1,7 @@
 from .. import BaseAPIClient
 from . import with_metaclass, ModelMetaClass
 from . import Field, PandoraModel, PandoraListModel, PandoraDictListModel
+from ..errors import ParameterMissing
 
 
 class Station(PandoraModel):
@@ -231,13 +232,13 @@ class AdItem(PlaylistModel):
         if self.tracking_tokens:
             self._api_client.register_ad(station_id, self.tracking_tokens)
         else:
-            raise ValueError('No ad tracking tokens available for '
-                             'registration.')
+            raise ParameterMissing('No ad tracking tokens available '
+                                          'for registration.')
 
     def prepare_playback(self):
         try:
             self.register_ad(self.station_id)
-        except ValueError as e:
+        except ParameterMissing as e:
             if not self.tracking_tokens:
                 # Ignore registration attempts if no ad tracking tokens are
                 # available

--- a/pandora/models/pandora.py
+++ b/pandora/models/pandora.py
@@ -221,6 +221,7 @@ class AdItem(PlaylistModel):
     image_url = Field("imageUrl")
     click_through_url = Field("clickThroughUrl")
     station_id = Field("stationId")
+    ad_token = Field("adToken")
 
     @property
     def is_ad(self):

--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -23,8 +23,6 @@ from .errors import PandoraException
 
 DEFAULT_API_HOST = "tuner.pandora.com/services/json/"
 
-logger = logging.getLogger(__name__)
-
 
 def retries(max_tries, exceptions=(Exception,)):
     """Function decorator implementing retrying logic.
@@ -234,13 +232,9 @@ class APITransport(object):
         self._start_request(method)
 
         url = self._build_url(method)
-        log_data = data
         data = self._build_data(method, data)
         params = self._build_params(method)
-        logger.info('TRANSPORT: \nMETHOD: {}\nPARAMS: {}\nDATA: {}\nURL: {}'
-                    .format(method, params, log_data, url))
         result = self._make_http_request(url, data, params)
-        logger.info('TRANSPORT: \nRESULT: {}\n'.format(result))
 
         return self._parse_response(result)
 

--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -9,7 +9,6 @@ exception.
 
 API consumers should use one of the API clients in the pandora.client package.
 """
-import logging
 import random
 import time
 import json

--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -26,7 +26,7 @@ DEFAULT_API_HOST = "tuner.pandora.com/services/json/"
 logger = logging.getLogger(__name__)
 
 
-def retries(max_tries, exceptions=(IOError,)):
+def retries(max_tries, exceptions=(Exception,)):
     """Function decorator implementing retrying logic.
 
     exceptions: A tuple of exception classes; default (Exception,)

--- a/pydora/utils.py
+++ b/pydora/utils.py
@@ -125,15 +125,6 @@ def iterate_forever(func, *args, **kwargs):
             yield playlistItem
         except StopIteration:
             output = func(*args, **kwargs)
-        except errors.ParameterMissing as e:
-            if isinstance(playlistItem, AdItem):
-                if (not playlistItem.tracking_tokens or
-                        len(playlistItem.tracking_tokens) == 0):
-                    # Ad item does not contain any tracking tokens, yield
-                    # without registering
-                    yield playlistItem
-            # Something else went wrong, re-raise
-            raise e
 
 
 class SilentPopen(subprocess.Popen):

--- a/tests/test_pandora/test_client.py
+++ b/tests/test_pandora/test_client.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from pandora.client import APIClient, BaseAPIClient
-from pandora.errors import InvalidAuthToken
+from pandora.errors import InvalidAuthToken, ParameterMissing
 from pandora.py2compat import Mock, call, patch
 from tests.test_pandora.test_models import TestAdItem
 
@@ -117,4 +117,4 @@ class TestGettingAds(TestCase):
         client = APIClient(transport, None, None, None, None)
         client.get_ad_metadata = Mock()
 
-        self.assertRaises(ValueError, client.get_ad_item, '', 'mock_token')
+        self.assertRaises(ParameterMissing, client.get_ad_item, '', 'mock_token')

--- a/tests/test_pandora/test_client.py
+++ b/tests/test_pandora/test_client.py
@@ -105,6 +105,7 @@ class TestGettingAds(TestCase):
 
             ad_item = client.get_ad_item('id_mock', 'token_mock')
             assert ad_item.station_id == 'id_mock'
+            assert ad_item.ad_token == 'token_mock'
 
             ad_metadata_mock.assert_has_calls([call("ad.getAdMetadata",
                                                       adToken='token_mock',

--- a/tests/test_pandora/test_client.py
+++ b/tests/test_pandora/test_client.py
@@ -64,12 +64,12 @@ class TestCallingAPIClient(TestCase):
             client = APIClient(transport, None, None, None, None)
             client._authenticate = Mock()
 
-            client.get_playlist('mock_token')
+            client.get_playlist('token_mock')
 
             playlist_mock.assert_has_calls([call("station.getPlaylist",
                                              audioAdPodCapable=True,
                                              includeTrackLength=True,
-                                             stationToken='mock_token',
+                                             stationToken='token_mock',
                                              xplatformAdCapable=True)])
 
 
@@ -103,11 +103,11 @@ class TestGettingAds(TestCase):
             client = APIClient(transport, None, None, None, None)
             client._authenticate = Mock()
 
-            ad_item = client.get_ad_item('mock_id', 'mock_token')
-            assert ad_item.station_id == 'mock_id'
+            ad_item = client.get_ad_item('id_mock', 'token_mock')
+            assert ad_item.station_id == 'id_mock'
 
             ad_metadata_mock.assert_has_calls([call("ad.getAdMetadata",
-                                                      adToken='mock_token',
+                                                      adToken='token_mock',
                                                       returnAdTrackingTokens=True,
                                                       supportAudioAds=True)])
 
@@ -117,4 +117,4 @@ class TestGettingAds(TestCase):
         client = APIClient(transport, None, None, None, None)
         client.get_ad_metadata = Mock()
 
-        self.assertRaises(ParameterMissing, client.get_ad_item, '', 'mock_token')
+        self.assertRaises(ParameterMissing, client.get_ad_item, '', 'token_mock')

--- a/tests/test_pandora/test_models.py
+++ b/tests/test_pandora/test_models.py
@@ -225,6 +225,8 @@ class TestAdItem(TestCase):
         api_client_mock = Mock(spec=APIClient)
         api_client_mock.default_audio_quality = APIClient.HIGH_AUDIO_QUALITY
         self.result = AdItem.from_json(api_client_mock, self.JSON_DATA)
+        self.result.station_id = 'station_id_mock'
+        self.result.ad_token = 'token_mock'
 
     def test_is_ad_is_true(self):
         assert self.result.is_ad is True

--- a/tests/test_pandora/test_models.py
+++ b/tests/test_pandora/test_models.py
@@ -253,3 +253,23 @@ class TestAdItem(TestCase):
             self.result.prepare_playback()
             assert self.result.register_ad.called
             assert super_mock.called
+
+    def test_prepare_playback_raises_paramater_missing(self):
+        with patch.object(PlaylistModel, 'prepare_playback') as super_mock:
+
+            self.result.register_ad = Mock(side_effect=ParameterMissing('No ad tracking tokens provided for '
+                                                                        'registration.')
+                                           )
+            self.assertRaises(ParameterMissing, self.result.prepare_playback)
+            assert self.result.register_ad.called
+            assert not super_mock.called
+
+    def test_prepare_playback_handles_paramater_missing_if_no_tokens(self):
+        with patch.object(PlaylistModel, 'prepare_playback') as super_mock:
+
+            self.result.tracking_tokens = []
+            self.result.register_ad = Mock(side_effect=ParameterMissing('No ad tracking tokens provided for '
+                                                                        'registration.'))
+            self.result.prepare_playback()
+            assert self.result.register_ad.called
+            assert super_mock.called

--- a/tests/test_pandora/test_models.py
+++ b/tests/test_pandora/test_models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pandora.py2compat import Mock, patch
 from pandora import APIClient
 from pandora.models.pandora import AdItem, PlaylistModel
+from pandora.errors import ParameterMissing
 
 import pandora.models as m
 
@@ -235,7 +236,7 @@ class TestAdItem(TestCase):
         assert self.result._api_client.register_ad.called
 
     def test_register_ad_raises_exception_if_no_tracking_tokens_available(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParameterMissing):
             self.result.tracking_tokens = []
             self.result._api_client.register_ad = Mock(spec=AdItem)
 

--- a/tests/test_pandora/test_models.py
+++ b/tests/test_pandora/test_models.py
@@ -205,19 +205,19 @@ class TestAdItem(TestCase):
     JSON_DATA = {
         'audioUrlMap': {
             'mediumQuality': {
-                'audioUrl': 'mock_med_url', 'bitrate': '64', 'protocol': 'http', 'encoding': 'aacplus'
+                'audioUrl': 'med_url_mock', 'bitrate': '64', 'protocol': 'http', 'encoding': 'aacplus'
             },
             'highQuality': {
-                'audioUrl': 'mock_high_url', 'bitrate': '64', 'protocol': 'http', 'encoding': 'aacplus'
+                'audioUrl': 'high_url_mock', 'bitrate': '64', 'protocol': 'http', 'encoding': 'aacplus'
             },
             'lowQuality': {
-                'audioUrl': 'mock_low_url', 'bitrate': '32', 'protocol': 'http', 'encoding': 'aacplus'}},
-            'clickThroughUrl': 'mock_click_url',
-            'imageUrl': 'mock_img_url',
+                'audioUrl': 'low_url_mock', 'bitrate': '32', 'protocol': 'http', 'encoding': 'aacplus'}},
+            'clickThroughUrl': 'click_url_mock',
+            'imageUrl': 'img_url_mock',
             'companyName': '',
             'title': '',
             'trackGain': '0.0',
-            'adTrackingTokens': ['mock_token_1', 'mock_token_2']
+            'adTrackingTokens': ['token_1_mock', 'token_2_mock']
     }
 
     def setUp(self):
@@ -230,9 +230,18 @@ class TestAdItem(TestCase):
 
     def test_register_ad(self):
         self.result._api_client.register_ad = Mock()
-        self.result.register_ad('id_dummy')
+        self.result.register_ad('id_mock')
 
         assert self.result._api_client.register_ad.called
+
+    def test_register_ad_raises_exception_if_no_tracking_tokens_available(self):
+        with self.assertRaises(ValueError):
+            self.result.tracking_tokens = []
+            self.result._api_client.register_ad = Mock(spec=AdItem)
+
+            self.result.register_ad('id_mock')
+
+            assert self.result._api_client.register_ad.called
 
     def test_prepare_playback(self):
         with patch.object(PlaylistModel, 'prepare_playback') as super_mock:

--- a/tests/test_pandora/test_transport.py
+++ b/tests/test_pandora/test_transport.py
@@ -6,7 +6,7 @@ from pandora.py2compat import Mock, call
 from tests.test_pandora.test_clientbuilder import TestSettingsDictBuilder
 
 
-class SysCallError(IOError):
+class SysCallError(Exception):
     pass
 
 

--- a/tests/test_pandora/test_transport.py
+++ b/tests/test_pandora/test_transport.py
@@ -6,7 +6,7 @@ from pandora.py2compat import Mock, call
 from tests.test_pandora.test_clientbuilder import TestSettingsDictBuilder
 
 
-class SysCallError(Exception):
+class SysCallError(IOError):
     pass
 
 

--- a/tests/test_pandora/test_transport.py
+++ b/tests/test_pandora/test_transport.py
@@ -18,7 +18,7 @@ class TestTransport(TestCase):
 
             time.sleep = Mock()
             client.transport._make_http_request = Mock(
-                    side_effect=SysCallError("mock_error"))
+                    side_effect=SysCallError("error_mock"))
             client.transport._start_request = Mock()
 
             client("method")

--- a/tests/test_pydora/test_utils.py
+++ b/tests/test_pydora/test_utils.py
@@ -18,22 +18,22 @@ class TestIterateForever(TestCase):
         with patch.object(APIClient, 'get_playlist') as get_playlist_mock:
             with patch.object(APIClient, 'register_ad', side_effect=ParameterMissing("ParameterMissing")):
 
-                station = Station.from_json(self.client, {'stationToken': 'dummy_token'})
-                dummy_ad = AdItem.from_json(self.client, {'station_id': 'dummy_id'})
-                get_playlist_mock.return_value=iter([dummy_ad])
+                station = Station.from_json(self.client, {'stationToken': 'mock_token'})
+                ad_mock = AdItem.from_json(self.client, {'station_id': 'mock_id'})
+                get_playlist_mock.return_value=iter([ad_mock])
 
                 station_iter = iterate_forever(station.get_playlist)
 
                 next_track = station_iter.next()
-                self.assertEqual(dummy_ad, next_track)
+                self.assertEqual(ad_mock, next_track)
 
     def test_reraise_missing_params_exception(self):
         with patch.object(APIClient, 'get_playlist', side_effect=ParameterMissing("ParameterMissing")) as get_playlist_mock:
                 with self.assertRaises(ParameterMissing):
 
-                    station = Station.from_json(self.client, {'stationToken': 'dummy_token'})
-                    dummy_track = PlaylistItem.from_json(self.client, {'token': 'dummy_token'})
-                    get_playlist_mock.return_value=iter([dummy_track])
+                    station = Station.from_json(self.client, {'stationToken': 'mock_token'})
+                    mock_track = PlaylistItem.from_json(self.client, {'token': 'mock_token'})
+                    get_playlist_mock.return_value=iter([mock_track])
 
                     station_iter = iterate_forever(station.get_playlist)
                     station_iter.next()

--- a/tests/test_pydora/test_utils.py
+++ b/tests/test_pydora/test_utils.py
@@ -18,8 +18,8 @@ class TestIterateForever(TestCase):
         with patch.object(APIClient, 'get_playlist') as get_playlist_mock:
             with patch.object(APIClient, 'register_ad', side_effect=ParameterMissing("ParameterMissing")):
 
-                station = Station.from_json(self.client, {'stationToken': 'mock_token'})
-                ad_mock = AdItem.from_json(self.client, {'station_id': 'mock_id'})
+                station = Station.from_json(self.client, {'stationToken': 'token_mock'})
+                ad_mock = AdItem.from_json(self.client, {'station_id': 'id_mock'})
                 get_playlist_mock.return_value=iter([ad_mock])
 
                 station_iter = iterate_forever(station.get_playlist)
@@ -31,9 +31,9 @@ class TestIterateForever(TestCase):
         with patch.object(APIClient, 'get_playlist', side_effect=ParameterMissing("ParameterMissing")) as get_playlist_mock:
                 with self.assertRaises(ParameterMissing):
 
-                    station = Station.from_json(self.client, {'stationToken': 'mock_token'})
-                    mock_track = PlaylistItem.from_json(self.client, {'token': 'mock_token'})
-                    get_playlist_mock.return_value=iter([mock_track])
+                    station = Station.from_json(self.client, {'stationToken': 'token_mock'})
+                    track_mock = PlaylistItem.from_json(self.client, {'token': 'token_mock'})
+                    get_playlist_mock.return_value=iter([track_mock])
 
                     station_iter = iterate_forever(station.get_playlist)
                     station_iter.next()


### PR DESCRIPTION
This PR does a few things to try and make playback more robust:

- raise ```ParameterMissing``` exceptions instead of ```ValueError``` to better align with what we get back from Pandora. This means that consumers will only have to deal with one type of exception for any errors related to required parameters not being provided, whether to the API or the Pandora server.

- if a PlaylistItem does not have ```audio_url```, then we know it will be unplayable and don't need to make a call to the Pandora server.

- ```AdItem.register_ad``` now raises the ```ParameterMissing``` exception if no ```tracking_tokens``` are available. We know we're going to get this result from Pandora so can short-circuit the expensive network call and provide feedback to the consumer earlier on. In my testing a surprisingly large number of ads do not have any tokens available (maybe one in three).

- when we changed ```transport.retries``` to trigger for all types of exceptions, an unintended side effect was that we would also retry Pandora server requests for which we got valid error codes back (and then get the same result multiple times). The function now skips the retry if Pandora responded as it should on the first attempt.

- simplify ```utils.iterate_forever``` - handling the ```ParamterMissing``` exception is now done in the API call, where I think it belongs. The question becomes whether it is sensible to silence this error. I think it is: because we are only doing it in ```prepare_playback``` if no ad tracking tokens are available, and there is nothing we can do about it. But we can still play the ad if it has a valid ```audio_url```, and this feels more in line with what is intended than simply skipping over it.

- changed the convention used for string constants and parameter names in the tests I created so that it is easier to distinguish the parameter type when reading. Is there some PEP or similar convention that you are aware of?

I'd like to propose that we keep this PR open for a bit longer while we test and refine. Maybe it would make sense to add a 'develop' branch to the repository for these types of issues and testing at some point?