### PR TITLE
Fix to avoid retries on PandoraExceptions

### DIFF
--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -56,8 +56,6 @@ def retries(max_tries, exceptions=(Exception,)):
                             0.5, 2, max_tries - retries_left))
                     else:
                         raise
-                else:
-                    break
 
         return function
 

--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -50,7 +50,7 @@ def retries(max_tries, exceptions=(Exception,)):
                     # Don't retry for PandoraExceptions - unlikely that result
                     # will change for same set of input parameters.
                     if isinstance(e, PandoraException):
-                        continue
+                        break
                     if retries_left > 0:
                         time.sleep(delay_exponential(
                             0.5, 2, max_tries - retries_left))

--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -50,7 +50,7 @@ def retries(max_tries, exceptions=(Exception,)):
                     # Don't retry for PandoraExceptions - unlikely that result
                     # will change for same set of input parameters.
                     if isinstance(e, PandoraException):
-                        break
+                        raise
                     if retries_left > 0:
                         time.sleep(delay_exponential(
                             0.5, 2, max_tries - retries_left))

--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -86,14 +86,14 @@ class RetryingSession(requests.Session):
     """Requests Session With Retry Support
 
     This Requests session uses an HTTPAdapter that retries on connection
-    failure at least once. The Pandora API is fairly aggressive about closing
+    failure three times. The Pandora API is fairly aggressive about closing
     connections on clients and the default session doesn't retry.
     """
 
     def __init__(self):
         super(RetryingSession, self).__init__()
-        self.mount('https://', HTTPAdapter(max_retries=1))
-        self.mount('http://', HTTPAdapter(max_retries=1))
+        self.mount('https://', HTTPAdapter(max_retries=3))
+        self.mount('http://', HTTPAdapter(max_retries=3))
 
 
 class APITransport(object):
@@ -224,7 +224,7 @@ class APITransport(object):
     # TODO: This decorator is a temporary workaround for handling
     # SysCallErrors, see: https://github.com/shazow/urllib3/issues/367.
     # Should be removed once a fix is applied in urllib3.
-    @retries(5)
+    @retries(3)
     def __call__(self, method, **data):
         self._start_request(method)
 

--- a/tests/test_pandora/test_transport.py
+++ b/tests/test_pandora/test_transport.py
@@ -1,5 +1,6 @@
 import time
 from unittest import TestCase
+from pandora.errors import PandoraException
 
 from pandora.py2compat import Mock, call
 
@@ -25,3 +26,16 @@ class TestTransport(TestCase):
 
         client.transport._start_request.assert_has_calls([call("method")])
         assert client.transport._start_request.call_count == 5
+
+    def test_call_should_not_retry_for_pandora_exceptions(self):
+        client = TestSettingsDictBuilder._build_minimal()
+
+        time.sleep = Mock()
+        client.transport._make_http_request = Mock(
+                side_effect=PandoraException("error_mock"))
+        client.transport._start_request = Mock()
+
+        client("method")
+
+        client.transport._start_request.assert_has_calls([call("method")])
+        assert client.transport._start_request.call_count == 1


### PR DESCRIPTION
Silly mistake on my part means that the loop would not actually terminate if a PandoraException was raised.

This change avoids the retry for PandoraExceptions, removes unreachable code, and adds a test case for the retry logic.