### PR TITLE
Fix SearchResult model

### DIFF
--- a/pandora/models/pandora.py
+++ b/pandora/models/pandora.py
@@ -278,8 +278,8 @@ class Bookmark(PandoraModel):
 
 class BookmarkList(PandoraModel):
 
-    songs = Field("songs", formatter=PandoraModel.from_json_list)
-    artists = Field("artists", formatter=PandoraModel.from_json_list)
+    songs = Field("songs", formatter=Bookmark.from_json_list)
+    artists = Field("artists", formatter=Bookmark.from_json_list)
 
 
 class SearchResultItem(PandoraModel):
@@ -287,7 +287,7 @@ class SearchResultItem(PandoraModel):
     artist = Field("artistName")
     song_name = Field("songName")
     score = Field("score")
-    likely_match = Field("likelyMatch")
+    likely_match = Field("likelyMatch", default=False)
     token = Field("musicToken")
 
     @property
@@ -305,8 +305,8 @@ class SearchResult(PandoraModel):
 
     nearest_matches_available = Field("nearMatchesAvailable")
     explanation = Field("explanation")
-    songs = Field("songs", formatter=PandoraModel.from_json_list)
-    artists = Field("artists", formatter=PandoraModel.from_json_list)
+    songs = Field("songs", formatter=SearchResultItem.from_json_list)
+    artists = Field("artists", formatter=SearchResultItem.from_json_list)
 
 
 class GenreStationList(PandoraDictListModel):


### PR DESCRIPTION
The ``songs`` and ``artists`` fields of ``SearchResult`` is not being populated correctly.

This PR fixes that (and the same issue that I think might also occur for ``BookmarkList``) and adds test cases to validate.