### PR TITLE
Fixes broken user login

### DIFF
--- a/pandora/transport.py
+++ b/pandora/transport.py
@@ -188,8 +188,9 @@ class APITransport:
             pass
 
         params = self.remove_empty_values(params)
+        headers = { "User-agent": "pianobar-2022.04.01" }
 
-        result = self._http.post(url, data=data, params=params)
+        result = self._http.post(url, data=data, params=params, headers=headers)
         result.raise_for_status()
         return result.content
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Pandora has only whitelisted a few unofficial clients like Pianobar. So we have to pretend to be Pianobar to continue to work.

**Which issue(s) this PR fixes**:

Fixes #69 (heh)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
